### PR TITLE
Implement file persistence for todo items

### DIFF
--- a/src/main/java/nl/inholland/fxtodoapp/TodoItem.java
+++ b/src/main/java/nl/inholland/fxtodoapp/TodoItem.java
@@ -1,7 +1,12 @@
 package nl.inholland.fxtodoapp;
 
-// TODO: Make class serializable
-public class TodoItem {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class TodoItem implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String description;
     private boolean completed;

--- a/src/main/java/nl/inholland/fxtodoapp/TodoItemService.java
+++ b/src/main/java/nl/inholland/fxtodoapp/TodoItemService.java
@@ -1,24 +1,65 @@
 package nl.inholland.fxtodoapp;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 public class TodoItemService {
 
-    private List<TodoItem> items;
+    private static final String STORAGE_FILE_NAME = "todo-items.dat";
+
+    private final List<TodoItem> items;
+    private final Path storagePath;
 
     public TodoItemService() {
+        this(Path.of(System.getProperty("user.home"), ".fxtodoapp", STORAGE_FILE_NAME));
+    }
+
+    TodoItemService(Path storagePath) {
+        this.storagePath = storagePath;
         items = new ArrayList<>();
         items.add(new TodoItem("Test this app", false));
         items.add(new TodoItem("Just make sure it works", false));
     }
 
     public void save() {
-        // TODO: Save items to disk
+        try {
+            if (storagePath.getParent() != null) {
+                Files.createDirectories(storagePath.getParent());
+            }
+
+            try (ObjectOutputStream outputStream =
+                         new ObjectOutputStream(Files.newOutputStream(storagePath))) {
+                outputStream.writeObject(new ArrayList<>(items));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to save todo items", e);
+        }
     }
 
     public void load() {
-        // TODO: Load items from disk
+        if (!Files.exists(storagePath)) {
+            return;
+        }
+
+        try (ObjectInputStream inputStream =
+                     new ObjectInputStream(Files.newInputStream(storagePath))) {
+            Object data = inputStream.readObject();
+            if (data instanceof List<?> list) {
+                items.clear();
+                for (Object object : list) {
+                    if (object instanceof TodoItem todoItem) {
+                        items.add(todoItem);
+                    }
+                }
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("Unable to load todo items", e);
+        }
     }
 
     public List<TodoItem> getItems() {


### PR DESCRIPTION
## Summary
- make todo items serializable so they can be persisted
- add filesystem-backed save and load support to the service, storing data under the user home directory

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d508c8dd0c8331b88b5629eceb9402